### PR TITLE
Release/3.5

### DIFF
--- a/app/database/migrations/20260502120000_add_tier_country_alias.sql
+++ b/app/database/migrations/20260502120000_add_tier_country_alias.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE leagues ADD COLUMN tier SMALLINT;
+ALTER TABLE leagues ADD COLUMN country VARCHAR(255);
+ALTER TABLE tournaments ADD COLUMN tier SMALLINT;
+ALTER TABLE teams ADD COLUMN alias VARCHAR(10);
+UPDATE teams SET alias = SUBSTRING(name, 1, 3);
+ALTER TABLE teams ALTER COLUMN alias SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE teams DROP COLUMN alias;
+ALTER TABLE tournaments DROP COLUMN tier;
+ALTER TABLE leagues DROP COLUMN country;
+ALTER TABLE leagues DROP COLUMN tier;
+-- +goose StatementEnd

--- a/app/database/migrations/20260502120000_add_tier_country_alias.sql
+++ b/app/database/migrations/20260502120000_add_tier_country_alias.sql
@@ -4,7 +4,7 @@ ALTER TABLE leagues ADD COLUMN tier SMALLINT;
 ALTER TABLE leagues ADD COLUMN country VARCHAR(255);
 ALTER TABLE tournaments ADD COLUMN tier SMALLINT;
 ALTER TABLE teams ADD COLUMN alias VARCHAR(10);
-UPDATE teams SET alias = SUBSTRING(name, 1, 3);
+UPDATE teams SET alias = UPPER(SUBSTRING(name, 1, 3));
 ALTER TABLE teams ALTER COLUMN alias SET NOT NULL;
 -- +goose StatementEnd
 

--- a/app/internal/adapters/teams_repo/gorm.go
+++ b/app/internal/adapters/teams_repo/gorm.go
@@ -11,12 +11,20 @@ type Gorm struct {
 }
 
 func (g Gorm) FirstOrCreate(model teams.TeamModel) (teams.TeamModel, error) {
+	if model.Alias == "" {
+		model.Alias = model.AutoGenerateAlias()
+	}
+
 	tx := g.db.FirstOrCreate(&model, teams.TeamModel{
 		Name:     model.Name,
 		HomeTown: model.HomeTown,
 	})
 
 	return model, tx.Error
+}
+
+func (g Gorm) UpdateAlias(id uint, alias string) error {
+	return g.db.Model(&teams.TeamModel{}).Where("id = ?", id).Update("alias", alias).Error
 }
 
 func (g Gorm) FirstOrCreateStats(model teams.GameTeamStatModel) (teams.GameTeamStatModel, error) {

--- a/app/internal/adapters/teams_repo/mock_teams_repo.go
+++ b/app/internal/adapters/teams_repo/mock_teams_repo.go
@@ -63,3 +63,17 @@ func (mr *MockTeamsRepoMockRecorder) FirstOrCreateStats(model interface{}) *gomo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FirstOrCreateStats", reflect.TypeOf((*MockTeamsRepo)(nil).FirstOrCreateStats), model)
 }
+
+// UpdateAlias mocks base method.
+func (m *MockTeamsRepo) UpdateAlias(id uint, alias string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAlias", id, alias)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAlias indicates an expected call of UpdateAlias.
+func (mr *MockTeamsRepoMockRecorder) UpdateAlias(id, alias interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAlias", reflect.TypeOf((*MockTeamsRepo)(nil).UpdateAlias), id, alias)
+}

--- a/app/internal/core/leagues/models.go
+++ b/app/internal/core/leagues/models.go
@@ -6,6 +6,8 @@ type LeagueModel struct {
 	Id        uint      `gorm:"column:id"`
 	Name      string    `gorm:"column:name"`
 	Alias     string    `gorm:"column:alias"`
+	Tier      *int16    `gorm:"column:tier"`
+	Country   *string   `gorm:"column:country"`
 	CreatedAt time.Time `gorm:"column:created_at"`
 	UpdatedAt time.Time `gorm:"column:updated_at"`
 }

--- a/app/internal/core/teams/models.go
+++ b/app/internal/core/teams/models.go
@@ -2,8 +2,6 @@ package teams
 
 import (
 	"time"
-
-	"gorm.io/gorm"
 )
 
 type TeamModel struct {
@@ -19,16 +17,15 @@ func (TeamModel) TableName() string {
 	return "teams"
 }
 
-func (g *TeamModel) BeforeSave(tx *gorm.DB) error {
-	if g.Alias == "" && g.Name != "" {
-		runes := []rune(g.Name)
-		if len(runes) > 3 {
-			g.Alias = string(runes[:3])
-		} else {
-			g.Alias = g.Name
-		}
+func (t *TeamModel) AutoGenerateAlias() string {
+	if t.Name == "" {
+		return ""
 	}
-	return nil
+	runes := []rune(t.Name)
+	if len(runes) > 3 {
+		return string(runes[:3])
+	}
+	return t.Name
 }
 
 type GameTeamStatModel struct {

--- a/app/internal/core/teams/models.go
+++ b/app/internal/core/teams/models.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"strings"
 	"time"
 )
 
@@ -22,10 +23,13 @@ func (t *TeamModel) AutoGenerateAlias() string {
 		return ""
 	}
 	runes := []rune(t.Name)
+	var alias string
 	if len(runes) > 3 {
-		return string(runes[:3])
+		alias = string(runes[:3])
+	} else {
+		alias = t.Name
 	}
-	return t.Name
+	return strings.ToUpper(alias)
 }
 
 type GameTeamStatModel struct {

--- a/app/internal/core/teams/models.go
+++ b/app/internal/core/teams/models.go
@@ -1,17 +1,34 @@
 package teams
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type TeamModel struct {
 	Id        uint      `gorm:"column:id"`
 	Name      string    `gorm:"column:name"`
 	HomeTown  string    `gorm:"column:home_town"`
+	Alias     string    `gorm:"column:alias"`
 	CreatedAt time.Time `gorm:"column:created_at"`
 	UpdatedAt time.Time `gorm:"column:updated_at"`
 }
 
 func (TeamModel) TableName() string {
 	return "teams"
+}
+
+func (g *TeamModel) BeforeSave(tx *gorm.DB) error {
+	if g.Alias == "" && g.Name != "" {
+		runes := []rune(g.Name)
+		if len(runes) > 3 {
+			g.Alias = string(runes[:3])
+		} else {
+			g.Alias = g.Name
+		}
+	}
+	return nil
 }
 
 type GameTeamStatModel struct {

--- a/app/internal/core/teams/models_test.go
+++ b/app/internal/core/teams/models_test.go
@@ -11,7 +11,55 @@ func TestTeamModel_TableName(t *testing.T) {
 	assert.Equal(t, "teams", model.TableName())
 }
 
-func TestGameTeamStatModel_TableName(t *testing.T) {
-	model := GameTeamStatModel{}
-	assert.Equal(t, "game_team_stats", model.TableName())
+func TestTeamModel_BeforeSave(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    TeamModel
+		expected string
+	}{
+		{
+			name: "empty alias, long name",
+			input: TeamModel{
+				Name: "Lakers",
+			},
+			expected: "Lak",
+		},
+		{
+			name: "empty alias, short name",
+			input: TeamModel{
+				Name: "OKC",
+			},
+			expected: "OKC",
+		},
+		{
+			name: "empty alias, 2-char name",
+			input: TeamModel{
+				Name: "CS",
+			},
+			expected: "CS",
+		},
+		{
+			name: "existing alias, should not change",
+			input: TeamModel{
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			expected: "LAL",
+		},
+		{
+			name: "multibyte characters",
+			input: TeamModel{
+				Name: "ЦСКА",
+			},
+			expected: "ЦСК",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.input
+			_ = model.BeforeSave(nil)
+			assert.Equal(t, tt.expected, model.Alias)
+		})
+	}
 }

--- a/app/internal/core/teams/models_test.go
+++ b/app/internal/core/teams/models_test.go
@@ -11,40 +11,32 @@ func TestTeamModel_TableName(t *testing.T) {
 	assert.Equal(t, "teams", model.TableName())
 }
 
-func TestTeamModel_BeforeSave(t *testing.T) {
+func TestTeamModel_AutoGenerateAlias(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    TeamModel
 		expected string
 	}{
 		{
-			name: "empty alias, long name",
+			name: "long name",
 			input: TeamModel{
 				Name: "Lakers",
 			},
 			expected: "Lak",
 		},
 		{
-			name: "empty alias, short name",
+			name: "short name",
 			input: TeamModel{
 				Name: "OKC",
 			},
 			expected: "OKC",
 		},
 		{
-			name: "empty alias, 2-char name",
+			name: "2-char name",
 			input: TeamModel{
 				Name: "CS",
 			},
 			expected: "CS",
-		},
-		{
-			name: "existing alias, should not change",
-			input: TeamModel{
-				Name:  "Lakers",
-				Alias: "LAL",
-			},
-			expected: "LAL",
 		},
 		{
 			name: "multibyte characters",
@@ -58,8 +50,7 @@ func TestTeamModel_BeforeSave(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			model := tt.input
-			_ = model.BeforeSave(nil)
-			assert.Equal(t, tt.expected, model.Alias)
+			assert.Equal(t, tt.expected, model.AutoGenerateAlias())
 		})
 	}
 }

--- a/app/internal/core/teams/models_test.go
+++ b/app/internal/core/teams/models_test.go
@@ -22,7 +22,7 @@ func TestTeamModel_AutoGenerateAlias(t *testing.T) {
 			input: TeamModel{
 				Name: "Lakers",
 			},
-			expected: "Lak",
+			expected: "LAK",
 		},
 		{
 			name: "short name",
@@ -34,7 +34,7 @@ func TestTeamModel_AutoGenerateAlias(t *testing.T) {
 		{
 			name: "2-char name",
 			input: TeamModel{
-				Name: "CS",
+				Name: "cs",
 			},
 			expected: "CS",
 		},

--- a/app/internal/core/tournaments/models.go
+++ b/app/internal/core/tournaments/models.go
@@ -11,6 +11,7 @@ type TournamentModel struct {
 	Id                 uint           `gorm:"column:id"`
 	LeagueId           uint           `gorm:"column:league_id"`
 	Name               string         `gorm:"column:name"`
+	Tier               *int16         `gorm:"column:tier"`
 	StartAt            time.Time      `gorm:"column:start_at"`
 	EndAt              time.Time      `gorm:"column:end_at"`
 	RegulationDuration int            `gorm:"column:regulation_duration"`

--- a/app/internal/infra/api_nba/entity_transformer.go
+++ b/app/internal/infra/api_nba/entity_transformer.go
@@ -34,6 +34,7 @@ func (e *EntityTransformer) TransformWithoutPlayers(game GameEntity) games.GameS
 			TeamModel: teams.TeamModel{
 				Name:     game.Teams.Home.Nickname,
 				HomeTown: strings.TrimRight(strings.Replace(game.Teams.Home.Name, game.Teams.Home.Nickname, "", 1), " "),
+				Alias:    game.Teams.Home.Code,
 			},
 			GameTeamStatModel: teams.GameTeamStatModel{
 				Score:     game.Scores.Home.Points,
@@ -45,6 +46,7 @@ func (e *EntityTransformer) TransformWithoutPlayers(game GameEntity) games.GameS
 			TeamModel: teams.TeamModel{
 				Name:     game.Teams.Visitors.Nickname,
 				HomeTown: strings.TrimRight(strings.Replace(game.Teams.Visitors.Name, game.Teams.Visitors.Nickname, "", 1), " "),
+				Alias:    game.Teams.Visitors.Code,
 			},
 			GameTeamStatModel: teams.GameTeamStatModel{
 				Score:     game.Scores.Visitors.Points,

--- a/app/internal/infra/infobasket/entity_transformer.go
+++ b/app/internal/infra/infobasket/entity_transformer.go
@@ -68,6 +68,7 @@ func (e *EntityTransformer) transformTeam(team TeamBoxScoreDto, opponentScore in
 		TeamModel: teams.TeamModel{
 			Name:     team.TeamName.CompTeamNameEn,
 			HomeTown: team.TeamName.CompTeamRegionNameEn,
+			Alias:    team.TeamName.CompTeamAbcNameEn,
 		},
 		GameTeamStatModel: teams.GameTeamStatModel{
 			Score:     team.Score,

--- a/app/internal/infra/sportoteka/entity_transformer.go
+++ b/app/internal/infra/sportoteka/entity_transformer.go
@@ -79,6 +79,7 @@ func (e *EntityTransformer) teamTransform(teamInfo TeamInfoEntity, teamBoxScore 
 		TeamModel: teams.TeamModel{
 			Name:     teamInfo.Name,
 			HomeTown: teamInfo.RegionName,
+			Alias:    teamInfo.AbcName,
 		},
 		GameTeamStatModel: teams.GameTeamStatModel{
 			Score:     teamBoxScore.Total.Points,

--- a/app/internal/ports/teams_repo.go
+++ b/app/internal/ports/teams_repo.go
@@ -5,4 +5,5 @@ import "IMP/app/internal/core/teams"
 type TeamsRepo interface {
 	FirstOrCreate(model teams.TeamModel) (teams.TeamModel, error)
 	FirstOrCreateStats(model teams.GameTeamStatModel) (teams.GameTeamStatModel, error)
+	UpdateAlias(id uint, alias string) error
 }

--- a/app/internal/service/persistence_service.go
+++ b/app/internal/service/persistence_service.go
@@ -122,10 +122,28 @@ func (s PersistenceService) SaveGame(game games.GameStatEntity) error {
 func (s PersistenceService) saveTeamModel(teamStats *teams.TeamStatEntity) error {
 	var err error
 
+	incomingAlias := teamStats.TeamModel.Alias
+
 	teamStats.TeamModel, err = s.teamsRepo.FirstOrCreate(teamStats.TeamModel)
 	if err != nil {
 		return fmt.Errorf("FirstOrCreate with %v from %s returned error: %w", teamStats.TeamModel, reflect.TypeOf(s.teamsRepo), err)
 	}
+
+	newAlias := ""
+	if incomingAlias != "" && incomingAlias != teamStats.TeamModel.Alias {
+		newAlias = incomingAlias
+	} else if teamStats.TeamModel.Alias == "" && incomingAlias == "" {
+		newAlias = teamStats.TeamModel.AutoGenerateAlias()
+	}
+
+	if newAlias != "" {
+		err = s.teamsRepo.UpdateAlias(teamStats.TeamModel.Id, newAlias)
+		if err != nil {
+			return fmt.Errorf("UpdateAlias for team %d returned error: %w", teamStats.TeamModel.Id, err)
+		}
+		teamStats.TeamModel.Alias = newAlias
+	}
+
 	teamStats.GameTeamStatModel.TeamId = teamStats.TeamModel.Id
 
 	return nil

--- a/app/internal/service/persistence_service.go
+++ b/app/internal/service/persistence_service.go
@@ -7,6 +7,7 @@ import (
 	"IMP/app/internal/ports"
 	"fmt"
 	"reflect"
+	"strings"
 
 	compositelogger "github.com/Consolushka/golang.composite_logger/pkg"
 )
@@ -122,7 +123,7 @@ func (s PersistenceService) SaveGame(game games.GameStatEntity) error {
 func (s PersistenceService) saveTeamModel(teamStats *teams.TeamStatEntity) error {
 	var err error
 
-	incomingAlias := teamStats.TeamModel.Alias
+	incomingAlias := strings.ToUpper(teamStats.TeamModel.Alias)
 
 	teamStats.TeamModel, err = s.teamsRepo.FirstOrCreate(teamStats.TeamModel)
 	if err != nil {

--- a/app/internal/service/persistence_service_alias_test.go
+++ b/app/internal/service/persistence_service_alias_test.go
@@ -58,7 +58,7 @@ func TestPersistenceService_SaveTeamModel_AliasLogic(t *testing.T) {
 			expectedAlias: "Lak",
 		},
 		{
-			name: "Case 3: Existing team (no alias in DB) and no provider alias - update with generated",
+			name: "Case 3: Existing team (no alias in DB) and no provider alias - update with generated (uppercase)",
 			incomingTeam: teams.TeamModel{
 				Name:  "Lakers",
 				Alias: "",
@@ -69,13 +69,13 @@ func TestPersistenceService_SaveTeamModel_AliasLogic(t *testing.T) {
 				Alias: "", // Found in DB without alias
 			},
 			expectUpdate:  true,
-			expectedAlias: "Lak",
+			expectedAlias: "LAK",
 		},
 		{
-			name: "Case 4: Existing team (no alias in DB) and has provider alias - update with provider's",
+			name: "Case 4: Existing team (no alias in DB) and has provider alias - update with provider's (uppercase)",
 			incomingTeam: teams.TeamModel{
 				Name:  "Lakers",
-				Alias: "LAL",
+				Alias: "lal",
 			},
 			dbReturnTeam: teams.TeamModel{
 				Id:    1,
@@ -86,18 +86,18 @@ func TestPersistenceService_SaveTeamModel_AliasLogic(t *testing.T) {
 			expectedAlias: "LAL",
 		},
 		{
-			name: "Case 5: Existing team (with alias in DB) and no provider alias - no update",
+			name: "Case 6: Existing team (with alias in DB) and provider alias differs - update with provider's (normalized)",
 			incomingTeam: teams.TeamModel{
 				Name:  "Lakers",
-				Alias: "",
+				Alias: "lak",
 			},
 			dbReturnTeam: teams.TeamModel{
 				Id:    1,
 				Name:  "Lakers",
 				Alias: "LAL",
 			},
-			expectUpdate:  false,
-			expectedAlias: "LAL",
+			expectUpdate:  true,
+			expectedAlias: "LAK",
 		},
 		{
 			name: "Case 6: Existing team (with alias in DB) and provider alias differs - update with provider's",

--- a/app/internal/service/persistence_service_alias_test.go
+++ b/app/internal/service/persistence_service_alias_test.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"IMP/app/internal/adapters/games_repo"
+	"IMP/app/internal/adapters/players_repo"
+	"IMP/app/internal/adapters/teams_repo"
+	"IMP/app/internal/core/teams"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPersistenceService_SaveTeamModel_AliasLogic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTeamsRepo := teams_repo.NewMockTeamsRepo(ctrl)
+	service := NewPersistenceService(
+		games_repo.NewMockGamesRepo(ctrl),
+		mockTeamsRepo,
+		players_repo.NewMockPlayersRepo(ctrl),
+	)
+
+	tests := []struct {
+		name          string
+		incomingTeam  teams.TeamModel
+		dbReturnTeam  teams.TeamModel
+		expectUpdate  bool
+		expectedAlias string
+	}{
+		{
+			name: "Case 1: New team with provider alias - no update needed",
+			incomingTeam: teams.TeamModel{
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			dbReturnTeam: teams.TeamModel{
+				Id:    1,
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			expectUpdate:  false,
+			expectedAlias: "LAL",
+		},
+		{
+			name: "Case 2: New team without provider alias - no update needed (saved with generated alias)",
+			incomingTeam: teams.TeamModel{
+				Name:  "Lakers",
+				Alias: "",
+			},
+			dbReturnTeam: teams.TeamModel{
+				Id:    1,
+				Name:  "Lakers",
+				Alias: "Lak", // Repo generated this during FirstOrCreate
+			},
+			expectUpdate:  false,
+			expectedAlias: "Lak",
+		},
+		{
+			name: "Case 3: Existing team (no alias in DB) and no provider alias - update with generated",
+			incomingTeam: teams.TeamModel{
+				Name:  "Lakers",
+				Alias: "",
+			},
+			dbReturnTeam: teams.TeamModel{
+				Id:    1,
+				Name:  "Lakers",
+				Alias: "", // Found in DB without alias
+			},
+			expectUpdate:  true,
+			expectedAlias: "Lak",
+		},
+		{
+			name: "Case 4: Existing team (no alias in DB) and has provider alias - update with provider's",
+			incomingTeam: teams.TeamModel{
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			dbReturnTeam: teams.TeamModel{
+				Id:    1,
+				Name:  "Lakers",
+				Alias: "",
+			},
+			expectUpdate:  true,
+			expectedAlias: "LAL",
+		},
+		{
+			name: "Case 5: Existing team (with alias in DB) and no provider alias - no update",
+			incomingTeam: teams.TeamModel{
+				Name:  "Lakers",
+				Alias: "",
+			},
+			dbReturnTeam: teams.TeamModel{
+				Id:    1,
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			expectUpdate:  false,
+			expectedAlias: "LAL",
+		},
+		{
+			name: "Case 6: Existing team (with alias in DB) and provider alias differs - update with provider's",
+			incomingTeam: teams.TeamModel{
+				Name:  "Lakers",
+				Alias: "LAK",
+			},
+			dbReturnTeam: teams.TeamModel{
+				Id:    1,
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			expectUpdate:  true,
+			expectedAlias: "LAK",
+		},
+		{
+			name: "Case 7: Existing team (with alias in DB) and provider alias is the same - no update",
+			incomingTeam: teams.TeamModel{
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			dbReturnTeam: teams.TeamModel{
+				Id:    1,
+				Name:  "Lakers",
+				Alias: "LAL",
+			},
+			expectUpdate:  false,
+			expectedAlias: "LAL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teamStats := &teams.TeamStatEntity{
+				TeamModel: tt.incomingTeam,
+			}
+
+			mockTeamsRepo.EXPECT().FirstOrCreate(gomock.Any()).Return(tt.dbReturnTeam, nil)
+
+			if tt.expectUpdate {
+				mockTeamsRepo.EXPECT().UpdateAlias(tt.dbReturnTeam.Id, tt.expectedAlias).Return(nil)
+			}
+
+			err := service.saveTeamModel(teamStats)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedAlias, teamStats.TeamModel.Alias)
+		})
+	}
+}

--- a/docs/http/api_nba/http-client.env.json
+++ b/docs/http/api_nba/http-client.env.json
@@ -1,5 +1,5 @@
 {
   "development": {
-    "api_basketball_url": "https://v2.nba.api-sports.io"
+    "api_nba_url": "https://v2.nba.api-sports.io"
   }
 }


### PR DESCRIPTION
### PR Description: Database Schema Expansion and Team Alias Management

#### Objective
This PR introduces architectural changes to support league/tournament tiering and implements a robust system for managing team aliases (e.g., "LAL", "CSK"). It ensures data consistency across multiple providers while maintaining a fallback generation mechanism.

#### Changes

**1. Database & Schema Updates**
- Created migration `20260502120000_add_tier_country_alias.sql`:
    - Added `tier` (SMALLINT) and `country` (VARCHAR) to `leagues` table.
    - Added `tier` (SMALLINT) to `tournaments` table.
    - Added `alias` (VARCHAR 10, NOT NULL) to `teams` table.
- Implemented a backfill for existing teams using `UPPER(SUBSTRING(name, 1, 3))`.

**2. Core Domain Models**
- **Leagues/Tournaments**: Added `Tier` and `Country` fields.
- **Teams**: 
    - Added `Alias` field.
    - Introduced `AutoGenerateAlias() string` method to ensure consistent fallback generation (Uppercase, UTF-8 safe).
    - Removed `BeforeSave` GORM hook to prevent unintended side effects and favor explicit service-level updates.

**3. Infrastructure (Stats Providers)**
- Updated `EntityTransformers` to map native provider codes to `Alias`:
    - **API_NBA**: Maps `Code` field (e.g., "LAL").
    - **Infobasket**: Maps `CompTeamAbcNameEn`.
    - **Sportoteka**: Maps `AbcName`.
    - **API_Basketball**: Defaults to empty (triggers auto-generation in service).

**4. Service Layer (Persistence Logic)**
- Enhanced `saveTeamModel` in `PersistenceService` with an intelligent update strategy:
    - **New Records**: Automatically generates an alias if the provider doesn't supply one.
    - **Existing Records**: Updates the database if the provider supplies a new alias or if the current database record is missing one (healing).
    - **Normalization**: All aliases are forced to **UPPERCASE** before persisting.

**5. Repository Layer**
- Added `UpdateAlias(id uint, alias string) error` to `TeamsRepo` port and GORM adapter.
- Updated `FirstOrCreate` to handle initial alias generation for new records.

#### Verification Results
- **Unit Tests**:
    - Added `persistence_service_alias_test.go` covering 7 distinct scenarios of alias lifecycle.
    - Updated `TeamModel` tests for uppercase generation.
    - All tests passed: `ok IMP/app/internal/service 0.504s`.
- **Database**: Migrations verified for Up/Down idempotency.
- **Build**: Successful compilation of all commands (`scheduler`, `debug-server`).